### PR TITLE
Vagrant remote

### DIFF
--- a/provision/bootstrap_r10k.sh
+++ b/provision/bootstrap_r10k.sh
@@ -13,9 +13,17 @@ service pe-httpd restart
   /etc/puppetlabs/puppet/modules --ignore-requirements
 
 cat > /tmp/newsite.pp <<EOM
+case $::settings::server {
+  'xmaster.vagrant.vm': {
+    \$remote = '/vagrant'
+  }
+  default: {
+    \$remote = 'git@github.com:terrimonster/puppet-control.git'
+  }
+}
 class { 'r10k':
   version => '1.3.4',
-  remote => 'git@github.com:terrimonster/puppet-control.git',
+  remote => \$remote,
 }
 EOM
 echo "APPLYING R10K"

--- a/site/profile/manifests/puppet/params.pp
+++ b/site/profile/manifests/puppet/params.pp
@@ -3,16 +3,14 @@
 # classes. This makes your code less messy
 # and follows puppet best practices.
 class profile::puppet::params {
+  $hieradir = '"/etc/puppetlabs/puppet/environments/%{::environment}/hieradata"'
+  $basemodulepath = "${::settings::confdir}/modules:/opt/puppet/share/puppet/modules"
   case $::settings::server {
     'xmaster.vagrant.vm': {
       $remote = '/vagrant'
-      $hieradir = '/vagrant/hieradata'
-      $basemodulepath = "/vagrant/site:${::settings::confdir}/modules:/opt/puppet/share/puppet/modules"
     }
     default: {
       $remote = 'git@github.com:terrimonster/puppet-control.git'
-      $hieradir = '"/etc/puppetlabs/puppet/environments/%{::environment}/hieradata"'
-      $basemodulepath = "${::settings::confdir}/modules:/opt/puppet/share/puppet/modules"
     }
   }
 }

--- a/site/profile/manifests/puppet/params.pp
+++ b/site/profile/manifests/puppet/params.pp
@@ -3,15 +3,14 @@
 # classes. This makes your code less messy
 # and follows puppet best practices.
 class profile::puppet::params {
-
-  $remote = 'git@github.com:terrimonster/puppet-control.git'
-
   case $::settings::server {
     'xmaster.vagrant.vm': {
+      $remote = '/vagrant'
       $hieradir = '/vagrant/hieradata'
       $basemodulepath = "/vagrant/site:${::settings::confdir}/modules:/opt/puppet/share/puppet/modules"
     }
     default: {
+      $remote = 'git@github.com:terrimonster/puppet-control.git'
       $hieradir = '"/etc/puppetlabs/puppet/environments/%{::environment}/hieradata"'
       $basemodulepath = "${::settings::confdir}/modules:/opt/puppet/share/puppet/modules"
     }


### PR DESCRIPTION
I've been debating the pros and cons of this with myself for the last couple hours...
#### good
- xmaster will be configured much more similarly to production masters
- no more need to conditionally set paths or shoehorn `/vagrant` in front of them
#### slightly annoying
- The full r10k/git workflow becomes necessary with the vagrant environment.  I think the extra workflow practice would be good for new r10k users, though.
#### alternatives

While it would be nice to be able to test un-committed changes in the vagrant environment, I can't think of a way to cleanly override the `environment.conf` modulepath.

Currently, `profile::puppet::master` is prepending `/vagrant/site` to the default `basemodulepath`.  This unfortunately results in modulepaths with `/vagrant/site` in the middle due to `environment.conf` appending `$basemodulepath` to the environment modulepath.

My best idea is to add a long-lived branch to this repository containing _nothing_ but an environment.conf file setting `manifest` and `modulepath`, then configure the puppet environment for vagrant hosts via hiera or other conditional logic.  Unfortunately setting the modulepath complicates things further.
- using `/vagrant/modules` would require engineers to `r10k puppetfile install` to test changes to the `Puppetfile`
- using `$confdir/environments/$environment/modules` would prevent changes to the `Puppetfile` from being effected in the vagrant environment

The hieradata directory would also need to be determined conditionally with some of the code that 2dfb8e0 removes.  I think this would be enough to facilitate testing without commiting, but it feels dirty.  Is there a better way to handle this?
