### PR TITLE
simplify modulepath

### DIFF
--- a/environment.conf
+++ b/environment.conf
@@ -1,2 +1,2 @@
-modulepath = $confdir/environments/$environment/site:$confdir/environments/$environment/modules:$basemodulepath
+modulepath = site:modules:$basemodulepath
 environment_timeout = 0


### PR DESCRIPTION
Relative modulepaths conveniently start at the environment directory.
