### PR TITLE
Changes for PE 3.8

### DIFF
--- a/provision/bootstrap_r10k.sh
+++ b/provision/bootstrap_r10k.sh
@@ -15,7 +15,7 @@ case $::settings::server {
   }
 }
 class { 'r10k':
-  version => '1.4.1',
+  version => '1.5.1',
   remote => \$remote,
 }
 EOM

--- a/provision/bootstrap_r10k.sh
+++ b/provision/bootstrap_r10k.sh
@@ -8,10 +8,9 @@ else
   MODPATH='/etc/puppetlabs/puppet/environments/production/site'
 fi
 
-rm -rf /etc/puppetlabs/puppet/environments/production
-
 /opt/puppet/bin/puppet apply -e 'include profile::puppet::r10k' --modulepath=$MODPATH
 
+rm -rf /etc/puppetlabs/puppet/environments/production
 
 /opt/puppet/bin/r10k deploy environment -p production --puppetfile \
   --verbose debug

--- a/provision/bootstrap_r10k.sh
+++ b/provision/bootstrap_r10k.sh
@@ -1,32 +1,19 @@
 #!/bin/bash
 
+HOSTNAME=`hostname`
+
+if [[ $HOSTNAME =~ vagrant ]]; then
+  MODPATH='/vagrant/site'
+else
+  MODPATH='/etc/puppetlabs/puppet/environments/production/site'
+fi
+
 rm -rf /etc/puppetlabs/puppet/environments/production
 
-/opt/puppet/bin/puppet module install zack-r10k --modulepath \
-  /etc/puppetlabs/puppet/modules --ignore-requirements
+/opt/puppet/bin/puppet apply -e 'include profile::puppet::r10k' --modulepath=$MODPATH
 
-cat > /tmp/newsite.pp <<EOM
-case $::settings::server {
-  'xmaster.vagrant.vm': {
-    \$remote = '/vagrant'
-  }
-  default: {
-    \$remote = 'git@github.com:terrimonster/puppet-control.git'
-  }
-}
-class { 'r10k':
-  version => '1.5.1',
-  remote => \$remote,
-}
-EOM
-echo "APPLYING R10K"
-/opt/puppet/bin/puppet apply /tmp/newsite.pp \
-  --modulepath=/etc/puppetlabs/puppet/modules
 
 /opt/puppet/bin/r10k deploy environment -p production --puppetfile \
   --verbose debug
-echo "Sleeping for 10 seconds while prod env is recognized"
-
-sleep 10
 
 /opt/puppet/bin/puppet agent -t

--- a/provision/pe/answers/master.txt
+++ b/provision/pe/answers/master.txt
@@ -43,3 +43,4 @@ q_puppetmaster_enterpriseconsole_port=443
 q_puppetmaster_install=y
 q_run_updtvpkg=n
 q_vendor_packages_install=y
+q_enable_future_parser=n

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-PE_VERSION="3.7.2"
+PE_VERSION="3.8.0"
 
 ###########################################################
 ANSWERS=$1
-PE_URL="https://s3.amazonaws.com/pe-builds/released/${PE_VERSION}/puppet-enterprise-${PE_VERSION}-el-6-x86_64.tar.gz"
+#puppet-enterprise-3.8.0-rc0-622-g2d49fbb-el-6-x86_64
+PE_URL="https://s3.amazonaws.com/pe-builds/released/${PE_VERSION}/puppet-enterprise-${PE_VERSION}-rc0-622-g2d49fbb-el-6-x86_64.tar.gz"
 FILENAME=${PE_URL##*/}
 DIRNAME=${FILENAME%*.tar.gz}
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -4,8 +4,7 @@ PE_VERSION="3.8.0"
 
 ###########################################################
 ANSWERS=$1
-#puppet-enterprise-3.8.0-rc0-622-g2d49fbb-el-6-x86_64
-PE_URL="https://s3.amazonaws.com/pe-builds/released/${PE_VERSION}/puppet-enterprise-${PE_VERSION}-rc0-622-g2d49fbb-el-6-x86_64.tar.gz"
+PE_URL="https://s3.amazonaws.com/pe-builds/released/${PE_VERSION}/puppet-enterprise-${PE_VERSION}-el-6-x86_64.tar.gz"
 FILENAME=${PE_URL##*/}
 DIRNAME=${FILENAME%*.tar.gz}
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -50,8 +50,6 @@ fi
 ## Bootstrap the master
 if [ "$1" == 'master.txt' ]; then
 
-  ## deploy keys
-
   /vagrant/provision/bootstrap_r10k.sh
 
   echo "All done! Now ssh in using vagrant ssh xmaster and sudo to root!"

--- a/site/profile/manifests/base/linux.pp
+++ b/site/profile/manifests/base/linux.pp
@@ -1,7 +1,0 @@
-class profile::base::linux {
-  ## We want to be able to manage firewall rules for our demo
-  include firewall
-
-  ## We require EPEL for various things
-  include epel
-}

--- a/site/profile/manifests/gitlab.pp
+++ b/site/profile/manifests/gitlab.pp
@@ -44,16 +44,4 @@ class profile::gitlab {
     refreshonly => true,
   }
 
-  ## Firewall rules for Gitlab
-  firewall { '100 allow http and https access':
-    port   => [80, 443],
-    proto  => 'tcp',
-    action => 'accept',
-  }
-
-  firewall { '110 allow ssh':
-    port   => '22',
-    proto  => 'tcp',
-    action => 'accept',
-  }
 }

--- a/site/profile/manifests/puppet/master.pp
+++ b/site/profile/manifests/puppet/master.pp
@@ -1,13 +1,14 @@
 class profile::puppet::master (
     $hiera_eyaml = false,
     $autosign = false,
-    $environmentpath = "${::settings::confdir}/environments",
     $deploy_pub_key = "",
     $deploy_private_key = "",
-    $r10k_version = '1.4.1',
+    $environmentpath = $::profile::puppet::params::environmentpath,
 ) inherits profile::puppet::params {
-  validate_string($remote)
   validate_bool($hiera_eyaml,$autosign)
+
+  include profile::puppet::r10k
+
   File {
     owner => 'root',
     group => 'root',
@@ -24,21 +25,6 @@ class profile::puppet::master (
     backends  => $backends,
     eyaml     => $hiera_eyaml,
     notify    => Service['pe-puppetserver'],
-  }
-
-  class { 'r10k':
-    version => $r10k_version,
-    sources  => {
-      'control' => {
-        'remote'  => $profile::puppet::params::remote,
-        'basedir' => $environmentpath,
-        'prefix'  => false,
-      },
-    },
-    purgedirs         => [$environmentpath],
-    manage_modulepath => false,
-    mcollective       => true,
-    notify            => Service['pe-puppetserver'],
   }
 
   if $autosign {

--- a/site/profile/manifests/puppet/params.pp
+++ b/site/profile/manifests/puppet/params.pp
@@ -5,6 +5,7 @@
 class profile::puppet::params {
   $hieradir = '"/etc/puppetlabs/puppet/environments/%{::environment}/hieradata"'
   $basemodulepath = "${::settings::confdir}/modules:/opt/puppet/share/puppet/modules"
+  $environmentpath = "${::settings::confdir}/environments"
   case $::settings::server {
     'xmaster.vagrant.vm': {
       $remote = '/vagrant'

--- a/site/profile/manifests/puppet/r10k.pp
+++ b/site/profile/manifests/puppet/r10k.pp
@@ -1,0 +1,12 @@
+class profile::puppet::r10k (
+  $remote = $::profile::puppet::params::remote,
+  $environmentpath = $::profile::puppet::params::environmentpath,
+) inherits ::profile::puppet::params {
+  file { 'r10k_config':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    path    => '/etc/puppetlabs/r10k/r10k.yaml',
+    content => template('profile/r10k.yaml.erb'),
+  }
+}

--- a/site/profile/templates/r10k.yaml.erb
+++ b/site/profile/templates/r10k.yaml.erb
@@ -1,0 +1,4 @@
+sources:
+  mysource:
+    remote: <%= @remote %>
+    basedir: <%= @environmentpath %>

--- a/site/role/manifests/puppet/master.pp
+++ b/site/role/manifests/puppet/master.pp
@@ -1,5 +1,4 @@
 class role::puppet::master {
   include profile::base
-  include profile::base::linux
   include profile::puppet::master
 }

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -25,6 +25,11 @@ nodes:
     networks:
       - private_network:
           ip: 192.168.137.14
+    provisioners:
+      - shell:
+          path: provision/provision.sh
+          arguments:
+            - value: agent.txt
     synced_folders:
       - host: .
         guest: /vagrant

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -17,19 +17,14 @@ nodes:
     synced_folders:
       - host: .
         guest: /vagrant
-  xagent1:
-    hostname: xagent1.vagrant.vm
+  xagent:
+    hostname: xagent.vagrant.vm
     box: puppetlabs/centos-6.6-64-nocm
     memory: 512
     cpus: 1
     networks:
       - private_network:
           ip: 192.168.137.14
-    provisioners:
-      - shell:
-          path: provision/provision.sh
-          arguments:
-            - value: agent.txt
     synced_folders:
       - host: .
         guest: /vagrant


### PR DESCRIPTION
A whole bunch of changes so that this works with PE 3.8. The bootstrapping for vagrant/live master is much cleaner and simpler. puppet::profile::master no longer manages r10k since the new version installs r10k. There is a separate profile to manage the r10k.yaml configuration file since that still needs to be managed.

The master's answer file needs to include whether or not to enable future parser. This is set to no by default.
