### PR TITLE
Update to CentOS 7

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -174,3 +174,7 @@ That's it! Now you have a full vagrant test environment that mirrors what you ha
 This makes use of Greg Sarjeant's [data-driven-vagrantfile](https://github.com/gsarjeant/data-driven-vagrantfile)
 
 No Vagrant plugins are required.
+
+The `vagrant-vbguest` plugin is recommended because the upstream `centos` boxes
+do not ship with guest additions installed in the base box.  Install the plugin
+with: `vagrant plugin install vagrant-vbguest`.

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 PE_VERSION="2015.2.2"
+EL_VER="7"
 
 ###########################################################
 ANSWERS=$1
-PE_URL="https://pm.puppetlabs.com/puppet-enterprise/${PE_VERSION}/puppet-enterprise-${PE_VERSION}-el-6-x86_64.tar.gz"
+PE_URL="https://pm.puppetlabs.com/puppet-enterprise/${PE_VERSION}/puppet-enterprise-${PE_VERSION}-el-${EL_VER}-x86_64.tar.gz"
 FILENAME=${PE_URL##*/}
 DIRNAME=${FILENAME%*.tar.gz}
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -20,8 +20,10 @@ cat > /etc/hosts <<EOH
 192.168.137.14 xagent.vagrant.vm xagent
 EOH
 
-# turn off iptables
-/sbin/service iptables stop
+# Make sure the firewall is turned off
+if systemctl status iptables.service > /dev/null; then
+  systemctl stop iptables.service
+fi
 
 # download and full install only happens on master
 if [ "$1" == 'master.txt' ]; then

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -1,9 +1,9 @@
 boxes:
-  puppetlabs/centos-6.6-64-nocm: "puppetlabs/centos-6.6-64-nocm"
+  centos/7: "centos/7"
 nodes:
   xmaster:
     hostname: xmaster.vagrant.vm
-    box: puppetlabs/centos-6.6-64-nocm
+    box: centos/7
     memory: 4096
     cpus: 1
     networks:
@@ -19,7 +19,7 @@ nodes:
         guest: /vagrant
   xagent:
     hostname: xagent.vagrant.vm
-    box: puppetlabs/centos-6.6-64-nocm
+    box: centos/7
     memory: 512
     cpus: 1
     networks:


### PR DESCRIPTION
This patch updates the boxes to use https://atlas.hashicorp.com/centos/boxes/7 which seems to be updated almost twice a month.

There are problems, however, about half the time the boxes are bought up there is no IP address bound to eth0 and as a result provisioning can't continue.  I suggest this PR doesn't get merged until we can sort out the reliability issues bringing up eth0.  Hopefully this PR serves as a starting point for robust CentOS 7 support.

The world can't move to systemd fast enough, IMHO...
